### PR TITLE
Allow snapshot load/save from inside brewblox dir

### DIFF
--- a/brewblox_ctl/__main__.py
+++ b/brewblox_ctl/__main__.py
@@ -54,7 +54,7 @@ def usage_hint(ex):
             'Many commands only work if your current directory is a Brewblox directory.',
         ]
 
-        if utils.path_exists('{}/docker-compose.yml'.format(default_dir)):
+        if utils.is_brewblox_dir(default_dir):
             prompt += [
                 'It looks like you installed Brewblox in the default location.',
                 'To navigate there, run:',

--- a/brewblox_ctl/commands/install.py
+++ b/brewblox_ctl/commands/install.py
@@ -207,10 +207,12 @@ def init(dir, release, force, skip_confirm):
     """
     utils.confirm_mode()
 
-    if utils.path_exists(dir):
-        if force or utils.confirm('The `{}` directory already exists. '
-                                  'Do you want to continue and erase the current contents?'.format(dir)):
-            sh('sudo rm -rf {}'.format(dir))
+    if utils.path_exists(dir) and not utils.is_empty_dir(dir):
+        if not utils.is_brewblox_dir(dir):
+            raise FileExistsError('`{}` is not a Brewblox directory.'.format(dir))
+        if force or utils.confirm('`{}` already exists. '.format(dir) +
+                                  'Do you want to continue and erase its content?'):
+            sh('sudo rm -rf {}/*'.format(dir))
         else:
             return
 

--- a/brewblox_ctl/utils.py
+++ b/brewblox_ctl/utils.py
@@ -5,7 +5,7 @@ Utility functions
 import re
 from os import getcwd
 from os import getenv as getenv_
-from os import path
+from os import listdir, path
 from pathlib import Path
 from platform import machine
 from shutil import which
@@ -14,6 +14,7 @@ from types import GeneratorType
 
 import click
 from dotenv import set_key, unset_key
+from dotenv.main import dotenv_values
 
 from brewblox_ctl import const
 
@@ -159,6 +160,17 @@ def is_docker_user():
 
 def is_brewblox_cwd():
     return bool(getenv(const.CFG_VERSION_KEY))
+
+
+def is_brewblox_dir(dir):
+    env_path = dir + '/.env'
+    if not path.isfile(env_path):
+        return False
+    return const.CFG_VERSION_KEY in dotenv_values(env_path)
+
+
+def is_empty_dir(dir):
+    return path.isdir(dir) and not listdir(dir)
 
 
 def optsudo():

--- a/test/commands/test_install.py
+++ b/test/commands/test_install.py
@@ -139,12 +139,15 @@ def test_install_existing_continue(m_utils, m_sh):
     ]
     invoke(install.install, '--no-use-defaults')
     m_utils.confirm.assert_any_call(matching(r'.*brewblox` directory already exists.*'))
-    assert m_sh.call_count == 4
+    assert m_sh.call_count == 3
     m_sh.assert_called_with('sudo reboot')
 
 
-def test_init(m_utils, m_sh):
+def test_init_force(m_utils, m_sh):
     m_utils.path_exists.return_value = True
+    m_utils.is_empty_dir.return_value = False
+    m_utils.confirm.return_value = False
+    m_utils.is_brewblox_dir.return_value = True
     m_utils.confirm.return_value = False
 
     invoke(install.init)
@@ -152,6 +155,14 @@ def test_init(m_utils, m_sh):
 
     invoke(install.init, '--force')
     assert m_sh.call_count > 0
+
+
+def test_init_invalid_dir(m_utils, m_sh):
+    m_utils.path_exists.return_value = True
+    m_utils.is_empty_dir.return_value = False
+    m_utils.is_brewblox_dir.return_value = False
+
+    invoke(install.init, _err=FileExistsError)
 
 
 def test_prepare_flasher(m_utils, m_sh):

--- a/test/commands/test_snapshot.py
+++ b/test/commands/test_snapshot.py
@@ -20,7 +20,6 @@ def m_input(mocker):
 def m_utils(mocker):
     m = mocker.patch(TESTED + '.utils')
     m.optsudo.return_value = 'SUDO '
-    m.is_brewblox_cwd.return_value = False
     m.docker_tag.side_effect = lambda v: v
     return m
 
@@ -32,34 +31,47 @@ def m_sh(mocker):
     return m
 
 
-def test_brewblox_cwd_error(m_utils, m_sh):
-    m_utils.is_brewblox_cwd.return_value = True
-
-    invoke(snapshot.save, _err=True)
-    invoke(snapshot.load, _err=True)
+def test_non_brewblox_dir_save(m_utils, m_sh):
+    m_utils.is_brewblox_dir.return_value = False
+    invoke(snapshot.save, _err=FileExistsError)
 
 
-def test_brewblox_save_invalid_dir(m_utils, m_sh):
-    m_utils.path_exists.return_value = False
-
-    invoke(snapshot.save, _err=True)
+def test_non_brewblox_dir_load(m_utils, m_sh):
+    m_utils.path_exists.return_value = True
+    m_utils.is_empty_dir.return_value = False
+    m_utils.is_brewblox_dir.return_value = False
+    invoke(snapshot.load, _err=FileExistsError)
 
 
 def test_save(m_utils, m_sh):
-    m_utils.path_exists.side_effect = [
-        True,  # compose file in dir
-        False,  # output file
-    ]
+    m_utils.path_exists.return_value = False
     invoke(snapshot.save)
-    m_sh.assert_any_call(matching(r'sudo tar -czf'))
+    m_sh.assert_any_call(matching(r'sudo tar -C .* -czf'))
+
+
+def test_save_defaults(m_utils, m_sh):
+    m_utils.path_exists.return_value = False
+
+    m_utils.is_brewblox_cwd.return_value = False
+    invoke(snapshot.save)
+    m_sh.assert_called_with(matching(r'sudo tar -C .* -czf ./brewblox.tar.gz brewblox'))
+
+    m_utils.is_brewblox_cwd.return_value = True
+    invoke(snapshot.save)
+    m_sh.assert_called_with(matching(r'sudo tar -C .* -czf ../brewblox.tar.gz brewblox-ctl'))
 
 
 def test_save_file_exists(m_utils, m_sh):
-    m_utils.path_exists.side_effect = [
-        True,  # compose file in dir
-        True,  # output file
-    ]
-    invoke(snapshot.save, _err=True)
+    m_utils.path_exists.return_value = True
+    m_utils.confirm.return_value = False
+
+    invoke(snapshot.save)
+    assert m_sh.call_count == 0
+
+    m_utils.confirm.return_value = True
+
+    invoke(snapshot.save)
+    assert m_sh.call_count == 2
 
 
 def test_save_overwrite(m_utils, m_sh):
@@ -75,6 +87,18 @@ def test_load(m_utils, m_sh):
     invoke(snapshot.load)
 
 
+def test_load_defaults(m_utils, m_sh):
+    m_utils.path_exists.return_value = False
+
+    m_utils.is_brewblox_cwd.return_value = False
+    invoke(snapshot.load)
+    m_sh.assert_called_with(matching(r'.* .*brewblox/'))
+
+    m_utils.is_brewblox_cwd.return_value = True
+    invoke(snapshot.load)
+    m_sh.assert_called_with(matching(r'.*brewblox-ctl/'))
+
+
 def test_load_empty(m_utils, m_sh):
     m_utils.path_exists.return_value = False
     m_utils.ctx_opts.return_value.dry_run = False
@@ -84,7 +108,15 @@ def test_load_empty(m_utils, m_sh):
     invoke(snapshot.load, _err=True)
 
 
-def test_load_output_exists(m_utils, m_sh):
+def test_load_overwrite(m_utils, m_sh):
     m_utils.path_exists.return_value = True
-    invoke(snapshot.load, _err=True)
+    m_utils.is_empty_dir.return_value = False
+    m_utils.is_brewblox_dir.return_value = True
+
+    m_utils.confirm.return_value = False
+
+    invoke(snapshot.load)
+    assert m_sh.call_count == 0
+
     invoke(snapshot.load, '--force')
+    assert m_sh.call_count > 0

--- a/test/commands/test_snapshot.py
+++ b/test/commands/test_snapshot.py
@@ -3,6 +3,8 @@ Tests brewblox_ctl.commands.snapshot
 """
 
 
+from os import path
+
 import pytest.__main__
 from brewblox_ctl.commands import snapshot
 from brewblox_ctl.testing import check_sudo, invoke, matching
@@ -58,7 +60,8 @@ def test_save_defaults(m_utils, m_sh):
 
     m_utils.is_brewblox_cwd.return_value = True
     invoke(snapshot.save)
-    m_sh.assert_called_with(matching(r'sudo tar -C .* -czf ../brewblox.tar.gz brewblox-ctl'))
+    cwd = path.basename(path.abspath('.'))
+    m_sh.assert_called_with(matching(r'sudo tar -C .* -czf ../brewblox.tar.gz ' + cwd))
 
 
 def test_save_file_exists(m_utils, m_sh):
@@ -96,7 +99,8 @@ def test_load_defaults(m_utils, m_sh):
 
     m_utils.is_brewblox_cwd.return_value = True
     invoke(snapshot.load)
-    m_sh.assert_called_with(matching(r'.*brewblox-ctl/'))
+    cwd = path.basename(path.abspath('.')) + '/'
+    m_sh.assert_called_with(matching(r'.*' + cwd))
 
 
 def test_load_empty(m_utils, m_sh):

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -113,11 +113,11 @@ def test_usage_hint(mocker, mocked_utils):
     assert mocked_utils.is_brewblox_cwd.call_count == 1
 
     mocked_utils.is_brewblox_cwd.return_value = False
-    mocked_utils.path_exists.return_value = False
+    mocked_utils.is_brewblox_dir.return_value = False
 
     main.usage_hint(UsageError('No such command'))
 
-    mocked_utils.path_exists.return_value = True
+    mocked_utils.is_brewblox_dir.return_value = True
 
     main.usage_hint(UsageError('No such command'))
 


### PR DESCRIPTION
Also adds the sanity check that target dir for init and snapshot load must be non-existant, empty, or a brewblox dir.