### PR TITLE
Ignore errors from docker install

### DIFF
--- a/brewblox_ctl/commands/install.py
+++ b/brewblox_ctl/commands/install.py
@@ -150,7 +150,7 @@ def install(ctx: click.Context,
     # Install docker
     if docker_install:
         utils.info('Installing docker...')
-        sh('curl -sL get.docker.com | sh')
+        sh('curl -sL get.docker.com | sh', check=False)
     else:
         utils.info('Skipped: docker install.')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "brewblox-ctl"
-version = "0.23.1"
+version = "0.23.2"
 description = "Brewblox management tool"
 authors = ["BrewPi <development@brewpi.com>"]
 license = "GPL-3.0"


### PR DESCRIPTION
The common dpkg error is fixed by restarting the Pi,
something that is required anyway.

Resolves #96