### PR TITLE
Edge release

### DIFF
--- a/brewblox_ctl/commands/flash.py
+++ b/brewblox_ctl/commands/flash.py
@@ -31,7 +31,7 @@ def run_particle_flasher(release: str, pull: bool, cmd: str):
     ])
 
     sh(f'{sudo}docker compose --log-level CRITICAL down', check=False)
-    sh(f'{sudo}docker run {opts} ghcr.io/brewblox/firmware-flasher:{tag} {cmd}')
+    sh(f'{sudo}docker run {opts} ghcr.io/brewblox/brewblox-firmware-flasher:{tag} {cmd}')
 
 
 def run_esp_flasher(release: str, pull: bool):

--- a/test/commands/test_flash.py
+++ b/test/commands/test_flash.py
@@ -38,7 +38,7 @@ def test_run_particle_flasher(m_utils, m_sh):
     flash.run_particle_flasher('taggart', True, 'do-stuff')
     m_sh.assert_called_with(
         'SUDO docker run -it --rm --privileged -v /dev:/dev --pull always ' +
-        'ghcr.io/brewblox/firmware-flasher:taggart do-stuff')
+        'ghcr.io/brewblox/brewblox-firmware-flasher:taggart do-stuff')
 
 
 def test_esptool(m_utils):
@@ -80,7 +80,7 @@ def test_photon_flash(m_usb, m_utils, m_sh):
     invoke(flash.flash, '--release develop --pull')
     m_sh.assert_called_with(
         'SUDO docker run -it --rm --privileged -v /dev:/dev --pull always ' +
-        'ghcr.io/brewblox/firmware-flasher:develop flash')
+        'ghcr.io/brewblox/brewblox-firmware-flasher:develop flash')
 
 
 def test_p1_flash(m_usb, m_utils, m_sh):
@@ -94,7 +94,7 @@ def test_p1_flash(m_usb, m_utils, m_sh):
     invoke(flash.flash, '--release develop --pull')
     m_sh.assert_called_with(
         'SUDO docker run -it --rm --privileged -v /dev:/dev --pull always ' +
-        'ghcr.io/brewblox/firmware-flasher:develop flash')
+        'ghcr.io/brewblox/brewblox-firmware-flasher:develop flash')
 
 
 def test_esp_flash(m_usb, m_utils, m_sh):
@@ -163,4 +163,4 @@ def test_particle(m_utils, m_sh):
     assert m_sh.call_count == 2
     m_sh.assert_called_with(
         'SUDO docker run -it --rm --privileged -v /dev:/dev --pull always ' +
-        'ghcr.io/brewblox/firmware-flasher:develop testey')
+        'ghcr.io/brewblox/brewblox-firmware-flasher:develop testey')


### PR DESCRIPTION
- poetry update
- Set python 3.7 as minimum required dependency
- Fix lint errors in readme
