### PR TITLE
version bump third party docker containers and v3 traefik config

### DIFF
--- a/brewblox_ctl/commands/update.py
+++ b/brewblox_ctl/commands/update.py
@@ -206,6 +206,64 @@ def update(update_ctl, update_ctl_done, pull, migrate, prune, from_version):
     if not update_ctl_done:
         utils.info(f'Starting update for brewblox {config.release} ...')
 
+    # Warn if user overrides Traefik in docker-compose.yml
+    try:
+        if utils.file_exists(const.COMPOSE_FILE):
+            user_compose = utils.read_compose()
+            traefik_svc = user_compose.get('services', {}).get('traefik')
+            if traefik_svc is not None:
+                img = traefik_svc.get('image', '')
+                if img and not img.startswith('traefik:3'):
+                    utils.warn(
+                        f'docker-compose.yml overrides the Traefik image ({img}). '
+                        'Brewblox now uses Traefik v3. Please review your override for compatibility.'
+                    )
+                else:
+                    utils.warn(
+                        'docker-compose.yml overrides the traefik service. '
+                        'If you customized command/entrypoints/labels, ensure they are compatible with Traefik v3.'
+                    )
+
+        # Warn if brewblox.yml config customizes Traefik file paths
+        if config.traefik.static_config_file != '/config/traefik.yml':
+            utils.warn(
+                f'brewblox.yml sets traefik.static_config_file to {config.traefik.static_config_file}. '
+                'Verify your static configuration is compatible with Traefik v3.'
+            )
+        if config.traefik.dynamic_config_dir != '/config/dynamic':
+            utils.warn(
+                f'brewblox.yml sets traefik.dynamic_config_dir to {config.traefik.dynamic_config_dir}. '
+                'Verify your dynamic configuration is compatible with Traefik v3.'
+            )
+
+        # Warn if any additional compose files define a custom traefik service
+        default_files = {'docker-compose.shared.yml', 'docker-compose.yml'}
+        for f in config.compose.files:
+            if f in default_files:
+                continue
+            try:
+                if utils.file_exists(f):
+                    data = utils.read_yaml(f)
+                    traefik_svc = (data or {}).get('services', {}).get('traefik')
+                    if traefik_svc is not None:
+                        img = traefik_svc.get('image', '')
+                        if img and not str(img).startswith('traefik:3'):
+                            utils.warn(
+                                f'{f} overrides the Traefik image ({img}). '
+                                'Brewblox now uses Traefik v3. Please review your override for compatibility.'
+                            )
+                        else:
+                            utils.warn(
+                                f'{f} overrides the traefik service. '
+                                'If you customized command/entrypoints/labels, ensure they are compatible with Traefik v3.'
+                            )
+            except Exception as ex:  # pragma: no cover
+                utils.warn(f'Failed to inspect {f} for Traefik overrides.')
+                utils.warn(utils.strex(ex))
+    except Exception as ex:  # pragma: no cover
+        utils.warn('Failed to inspect docker-compose.yml for Traefik overrides.')
+        utils.warn(utils.strex(ex))
+
     if update_ctl and not update_ctl_done:
         utils.info('Updating brewblox-ctl ...')
         actions.install_ctl_package()

--- a/brewblox_ctl/templates/docker-compose.shared.yml.j2
+++ b/brewblox_ctl/templates/docker-compose.shared.yml.j2
@@ -22,13 +22,13 @@ services:
       - traefik.tcp.routers.mqtt.rule=HostSNI(`*`)
       - traefik.tcp.routers.mqtt.tls=false
       - traefik.tcp.routers.mqtt.service=mqtt
-      - traefik.tcp.services.mqtt.loadBalancer.server.port=1883
+      - traefik.tcp.services.mqtt.loadbalancer.server.port=1883
       # MQTTS with TLS termination by traefik
       - traefik.tcp.routers.mqtts.entrypoints=mqtts
       - traefik.tcp.routers.mqtts.rule=HostSNI(`*`)
       - traefik.tcp.routers.mqtts.tls=true
       - traefik.tcp.routers.mqtts.service=mqtts
-      - traefik.tcp.services.mqtts.loadBalancer.server.port=1884
+      - traefik.tcp.services.mqtts.loadbalancer.server.port=1884
       # MQTT over websockets
       - traefik.http.services.eventbus.loadbalancer.server.port=15675
     volumes:
@@ -37,7 +37,7 @@ services:
         target: /mosquitto/include
 
   victoria:
-    image: victoriametrics/victoria-metrics:v1.112.0
+    image: victoriametrics/victoria-metrics:v1.129.1
     restart: unless-stopped
     command: --envflag.enable=true --envflag.prefix=VM_
     labels:
@@ -53,7 +53,7 @@ services:
         target: /victoria-metrics-data
 
   redis:
-    image: redis:6.0
+    image: redis:7.4
     restart: unless-stopped
     labels:
       - traefik.enable=false
@@ -88,7 +88,7 @@ services:
         read_only: true
 
   traefik:
-    image: traefik:2.10
+    image: traefik:3.6
     restart: unless-stopped
     command: --configFile={{ config.traefik.static_config_file }}
     volumes:

--- a/brewblox_ctl/templates/traefik-dynamic.yml.j2
+++ b/brewblox_ctl/templates/traefik-dynamic.yml.j2
@@ -22,8 +22,8 @@ http:
     cors:
       headers:
         accessControlAllowCredentials: true
-        accessControlAllowOriginListRegex:
-          - .*
+        accessControlAllowOriginList:
+          - "*"
         accessControlAllowMethods:
           - CONNECT
           - HEAD

--- a/brewblox_ctl/templates/traefik-static.yml.j2
+++ b/brewblox_ctl/templates/traefik-static.yml.j2
@@ -11,9 +11,10 @@
 api:
   dashboard: true
 providers:
+  providersThrottleDuration: 2s
   docker:
     constraints: "LabelRegex(`com.docker.compose.project`, `{{ config.compose.project }}`)"
-    defaultRule: 'PathPrefix(`/{% raw %}{{ index .Labels "com.docker.compose.service" }}{% endraw %}`)'
+    defaultRule: 'PathPrefix(`/{% raw %}{{ index .Labels "com.docker.compose.service" }}{% endraw %}`)"
   file:
     directory: {{ config.traefik.dynamic_config_dir }}
 entryPoints:
@@ -34,6 +35,7 @@ entryPoints:
       redirections:
         entryPoint:
           to: websecure
+          scheme: https
 {% endif %}
   admin:
     address: :{{ config.ports.admin }}

--- a/test/commands/test_update.py
+++ b/test/commands/test_update.py
@@ -82,6 +82,119 @@ def test_update(m_file_exists: Mock, m_getenv: Mock, m_migration: Mock):
     assert m_migration.migrate_env_config.call_count == 1
 
 
+def test_warn_traefik_overrides(
+    m_file_exists: Mock,
+    m_read_compose: Mock,
+    m_read_yaml: Mock,
+    m_warn: Mock,
+    m_get_config,  # autouse fixture returns config object
+):
+    # Ensure brewblox.yml exists to skip migrate_env_config
+    m_file_exists.add_existing_files(const.CONFIG_FILE, const.COMPOSE_FILE, 'extra-compose.yml')
+
+    # docker-compose.yml with custom traefik image v2
+    m_read_compose.side_effect = lambda: {
+        'services': {
+            'traefik': {'image': 'traefik:2.10'},
+        }
+    }
+
+    # extra compose file with traefik service too
+    def read_yaml_side_effect(path=None):
+        if path == 'extra-compose.yml':
+            return {'services': {'traefik': {'image': 'traefik:3.5'}}}
+        return {}
+
+    m_read_yaml.side_effect = read_yaml_side_effect
+
+    # Non-default static/dynamic paths
+    cfg = m_get_config
+    cfg.compose.files = ['docker-compose.shared.yml', 'docker-compose.yml', 'extra-compose.yml']
+    cfg.traefik.static_config_file = '/config/custom-traefik.yml'
+    cfg.traefik.dynamic_config_dir = '/config/custom-dynamic'
+
+    # Run update without side-effects
+    invoke(
+        update.update,
+        f'--from-version {const.CFG_VERSION} --no-update-ctl --no-pull --no-prune --no-migrate',
+    )
+
+    # We should have emitted multiple warnings
+    warn_msgs = [str(call.args[0]) for call in m_warn.call_args_list]
+    assert any('docker-compose.yml overrides the Traefik image' in m for m in warn_msgs)
+    assert any('brewblox.yml sets traefik.static_config_file' in m for m in warn_msgs)
+    assert any('brewblox.yml sets traefik.dynamic_config_dir' in m for m in warn_msgs)
+    assert any('extra-compose.yml overrides the traefik service' in m for m in warn_msgs)
+
+
+def test_warn_traefik_branches(
+    m_file_exists: Mock,
+    m_read_compose: Mock,
+    m_warn: Mock,
+    m_get_config,
+):
+    # Only default files exist; add a non-existent extra file to trigger file-exists=false branch
+    m_file_exists.add_existing_files(const.CONFIG_FILE, const.COMPOSE_FILE)
+
+    # docker-compose.yml with traefik defined but no image -> triggers generic override warning
+    m_read_compose.side_effect = lambda: {'services': {'traefik': {}}}
+
+    cfg = m_get_config
+    cfg.compose.files = ['docker-compose.shared.yml', 'docker-compose.yml', 'nonexistent.yml']
+    cfg.traefik.static_config_file = '/config/traefik.yml'
+    cfg.traefik.dynamic_config_dir = '/config/dynamic'
+
+    invoke(
+        update.update,
+        f'--from-version {const.CFG_VERSION} --no-update-ctl --no-pull --no-prune --no-migrate',
+    )
+
+    warn_msgs = [str(call.args[0]) for call in m_warn.call_args_list]
+    assert any('docker-compose.yml overrides the traefik service' in m for m in warn_msgs)
+
+
+def test_warn_traefik_extra_branches(
+    m_file_exists: Mock,
+    m_read_compose: Mock,
+    m_read_yaml: Mock,
+    m_get_config,
+):
+    # Both default files and two extra files exist
+    m_file_exists.add_existing_files(
+        const.CONFIG_FILE,
+        const.COMPOSE_FILE,
+        'extra-a.yml',
+        'extra-b.yml',
+    )
+
+    # docker-compose.yml without traefik service -> cover branch where traefik_svc is None
+    m_read_compose.side_effect = lambda: {'services': {'redis': {}}}
+
+    def read_yaml_side_effect(path=None):
+        if path == 'extra-a.yml':
+            # Exists but no traefik service -> cover false branch at 248
+            return {'services': {'other': {}}}
+        if path == 'extra-b.yml':
+            # Has traefik with v2 image -> cover branch at 251
+            return {'services': {'traefik': {'image': 'traefik:2.10'}}}
+        return {}
+
+    m_read_yaml.side_effect = read_yaml_side_effect
+
+    cfg = m_get_config
+    cfg.compose.files = [
+        'docker-compose.shared.yml',
+        'docker-compose.yml',
+        'extra-a.yml',
+        'extra-b.yml',
+    ]
+
+    invoke(
+        update.update,
+        f'--from-version {const.CFG_VERSION} --no-update-ctl --no-pull --no-prune --no-migrate',
+    )
+
+
 def test_check_version(mocker: MockerFixture):
     mocker.patch(TESTED + '.const.CFG_VERSION', '1.2.3')
     mocker.patch(TESTED + '.SystemExit', DummyError)


### PR DESCRIPTION
Docker v29 is not compatible with engine API <1.44.
Traefik version bump is needed for newest docker versions.

Also version bumped redis and victoria.

Print a warning if custom traefik config is detected.