### PR TITLE
Always reinstall brewblox-ctl

### DIFF
--- a/brewblox_ctl/actions.py
+++ b/brewblox_ctl/actions.py
@@ -213,7 +213,8 @@ def install_ctl_package():
                 ' On a synology NAS, you can install it from the package center community repo.'
             )
             raise SystemExit(1)
-        utils.sh('sudo apt-get update && sudo apt-get install -y git')
+        # Install git and python3-dev to enable building wheels when piwheels is unavailable
+        utils.sh('sudo apt-get update && sudo apt-get install -y git python3-dev')
 
     try:
         utils.sh('uv self update')
@@ -224,7 +225,9 @@ def install_ctl_package():
         raise SystemExit(1) from None
 
     utils.sh(
-        f'uv pip install --upgrade --extra-index-url=https://www.piwheels.org/simple --index-strategy=unsafe-best-match "git+https://github.com/brewblox/brewblox-ctl@{release}"'
+        f'uv pip install --upgrade --force-reinstall '
+        f'--extra-index-url=https://www.piwheels.org/simple --index-strategy=unsafe-best-match '
+        f'"git+https://github.com/brewblox/brewblox-ctl@{release}"'
     )
 
 

--- a/brewblox_ctl/const.py
+++ b/brewblox_ctl/const.py
@@ -42,6 +42,7 @@ APT_DEPENDENCIES = [
     'curl',
     'libssl-dev',
     'libffi-dev',
+    'python3-dev',
     'avahi-daemon',
     'git',
 ]

--- a/test/test_actions.py
+++ b/test/test_actions.py
@@ -167,7 +167,7 @@ def test_install_ctl_package(
 
     actions.install_ctl_package()
     m_sh.assert_called_with(
-        'uv pip install --upgrade --extra-index-url=https://www.piwheels.org/simple --index-strategy=unsafe-best-match "git+https://github.com/brewblox/brewblox-ctl@edge"'
+        'uv pip install --upgrade --force-reinstall --extra-index-url=https://www.piwheels.org/simple --index-strategy=unsafe-best-match "git+https://github.com/brewblox/brewblox-ctl@edge"'
     )
 
     m_sh.reset_mock()
@@ -175,14 +175,14 @@ def test_install_ctl_package(
     config.release = 'tag'
     actions.install_ctl_package()
     m_sh.assert_called_with(
-        'uv pip install --upgrade --extra-index-url=https://www.piwheels.org/simple --index-strategy=unsafe-best-match "git+https://github.com/brewblox/brewblox-ctl@tag"'
+        'uv pip install --upgrade --force-reinstall --extra-index-url=https://www.piwheels.org/simple --index-strategy=unsafe-best-match "git+https://github.com/brewblox/brewblox-ctl@tag"'
     )
 
     m_sh.reset_mock()
 
     uv_from_script = 'wget -qO- https://astral.sh/uv/install.sh | sh'
     uv_from_pip = 'pip install --upgrade uv'
-    git_install = 'sudo apt-get update && sudo apt-get install -y git'
+    git_install = 'sudo apt-get update && sudo apt-get install -y git python3-dev'
 
     # test uv not installed yet
     m_sh.reset_mock()
@@ -206,7 +206,7 @@ def test_install_ctl_package(
     m_command_exists.clear_existing_commands()
     m_command_exists.add_existing_commands('uv', 'apt-get')
     actions.install_ctl_package()
-    assert any(call[0][0] == git_install for call in m_sh.call_args_list), 'Expected git install'
+    assert any(call[0][0] == git_install for call in m_sh.call_args_list), 'Expected git + python3-dev install'
 
     # test uv, git already installed
     m_sh.reset_mock()
@@ -217,7 +217,7 @@ def test_install_ctl_package(
     actions.install_ctl_package()
     m_sh.assert_any_call('rm -f ./brewblox-ctl.tar.gz')
     m_sh.assert_called_with(
-        'uv pip install --upgrade --extra-index-url=https://www.piwheels.org/simple --index-strategy=unsafe-best-match "git+https://github.com/brewblox/brewblox-ctl@ctl_tag"'
+        'uv pip install --upgrade --force-reinstall --extra-index-url=https://www.piwheels.org/simple --index-strategy=unsafe-best-match "git+https://github.com/brewblox/brewblox-ctl@ctl_tag"'
     )
     assert not any(call[0][0] == uv_from_script for call in m_sh.call_args_list), 'Unexpected uv install from script'
     assert not any(call[0][0] == uv_from_pip for call in m_sh.call_args_list), 'Unexpected uv install from pip'


### PR DESCRIPTION
uv caching can cause brewblox-ctl to not be updated, because it is specified by branch.

We now force a reinstall.
We also now install python3-dev, so when piwheels has no binaries available for 32-bit, the system can at least build from the python sources.